### PR TITLE
Add agenttrace

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A curated collection of AI-powered coding tools, configurations, and resources t
 #### Tools
 
 - [ccusage](https://github.com/ryoppippi/ccusage)
+- [agenttrace](https://github.com/luoyuctl/agenttrace)
 - [ccundo](https://github.com/RonitSachdev/ccundo)
 - [opcode/Claudia](https://github.com/getAsterisk/opcode)
 - [slopus/happy](https://github.com/slopus/happy)


### PR DESCRIPTION
Add agenttrace to the Tools list near ccusage.

agenttrace is a local TUI for inspecting AI coding agent sessions, including cost, token usage, latency, failures, and reports. It complements usage-oriented Claude Code and AI coding workflow tools already listed in this section.

Checks:
- git diff --check
- No build/test entrypoint found